### PR TITLE
Add support for whitespace in .exe path name

### DIFF
--- a/PasteIntoFile/Program.cs
+++ b/PasteIntoFile/Program.cs
@@ -65,11 +65,11 @@ namespace PasteAsFile
 			{
 				var key = OpenDirectoryKey().CreateSubKey(@"Background\shell").CreateSubKey("Paste Into File");
 				key = key.CreateSubKey("command");
-				key.SetValue("", Application.ExecutablePath + " \"%V\"");
+				key.SetValue("\"", Application.ExecutablePath + "\" \"%V\"");
 
 				key = OpenDirectoryKey().CreateSubKey("shell").CreateSubKey("Paste Into File");
 				key = key.CreateSubKey("command");
-				key.SetValue("", Application.ExecutablePath + " \"%1\"");
+				key.SetValue("\"", Application.ExecutablePath + "\" \"%1\"");
 				MessageBox.Show("Application has been registered with your system", "Paste Into File", MessageBoxButtons.OK, MessageBoxIcon.Information);
 
 			}


### PR DESCRIPTION
Previously, if `PasteIntoFile.exe` was located in a path with whitespace in it (Ex: `C:\Users\Joe Smith\PasteIntoFile.exe`), Windows would fail to run it from the context menu.

This is fixed by surrounding the path in the registry with quotations. `PasteIntoFile.exe` can now be run from the context menu regardless of the location of the `.exe`.