### PR TITLE
Change default file name format to ISO_8601

### DIFF
--- a/PasteIntoFile/frmMain.cs
+++ b/PasteIntoFile/frmMain.cs
@@ -17,6 +17,7 @@ namespace PasteAsFile
 {
     public partial class frmMain : Form
     {
+        public const string DEFAULT_FILENAME_FORMAT = "yyyy-MM-dd HH.mm.ss";
         public string CurrentLocation { get; set; }
         public bool IsText { get; set; }
         public frmMain()
@@ -30,7 +31,7 @@ namespace PasteAsFile
         }
         private void frmMain_Load(object sender, EventArgs e)
         {
-            string filename = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\shell\Paste Into File\filename", "", null);
+            string filename = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\shell\Paste Into File\filename", "", null) ?? DEFAULT_FILENAME_FORMAT;
             if (filename == null)
             {
                 filename = "dd-MM-yyyy HH-mm-ss";

--- a/PasteIntoFile/frmMain.cs
+++ b/PasteIntoFile/frmMain.cs
@@ -32,10 +32,6 @@ namespace PasteAsFile
         private void frmMain_Load(object sender, EventArgs e)
         {
             string filename = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\shell\Paste Into File\filename", "", null) ?? DEFAULT_FILENAME_FORMAT;
-            if (filename == null)
-            {
-                filename = "dd-MM-yyyy HH-mm-ss";
-            }
             txtFilename.Text = DateTime.Now.ToString(filename);
             txtCurrentLocation.Text = CurrentLocation ?? @"C:\";
 


### PR DESCRIPTION
Changed the default file name format to ISO_8601.

The international format [ISO_8601](https://en.wikipedia.org/wiki/ISO_8601) allows to have the files sorted by name to be sorted by date as well.