### PR TITLE
Fix blurred UI for display scaling higher than 100%

### DIFF
--- a/PasteIntoFile/app.manifest
+++ b/PasteIntoFile/app.manifest
@@ -21,7 +21,7 @@
     </security>
   </trustInfo>
 
-  <application>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
     </windowsSettings>

--- a/PasteIntoFile/app.manifest
+++ b/PasteIntoFile/app.manifest
@@ -21,6 +21,12 @@
     </security>
   </trustInfo>
 
+  <application>
+    <windowsSettings>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- A list of all Windows versions that this application is designed to work with. 


### PR DESCRIPTION
Before:

![2020-03-08_145659](https://user-images.githubusercontent.com/1663053/76163587-05c07b80-6150-11ea-9c7a-9dcc657ea6da.png)


After:

![2020-03-08_145631](https://user-images.githubusercontent.com/1663053/76163590-0822d580-6150-11ea-99e8-fbbf8e3a24fe.png)


See:
- [Setting the default DPI awareness for a process](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/mt846517(v%3Dvs.85))